### PR TITLE
Add allowInsecureTLS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A modern VS Code extension to integrate with Gitea repositories, allowing you to
 - Timeline view showing events for issues and pull requests
 - VS Code theme-aware UI components
 
-## Configuration
+## Configuration(User Configuration)
 
 Add the following settings to your VS Code User settings(or simply open extension page, click on the settings icon and fill in the required text fields):
 
@@ -25,6 +25,34 @@ Add the following settings to your VS Code User settings(or simply open extensio
   "gitea.instanceURL": "[Your server instance address]",
   "gitea.owner": "[Owner of the gitea repo]",
   "gitea.repo": "[Repo name]",
+  "gitea.token": "[Access token for the user]",
+  "gitea.allowInsecureTLS": "[true if your gitea server use self signed certificate]"
+}
+```
+
+## Configuration(Project Configuration)
+
+> Do not write your token in the `.vscode/settings.json` if you upload `.vscode` folder to public git repository
+
+1. Add the following settings to your `.vscode/settings.json`:
+
+```json
+{
+  "gitea.instanceURL": "[Your server instance address]",
+  "gitea.owner": "[Owner of the gitea repo]",
+  "gitea.repo": "[Repo name]",
+  "gitea.allowInsecureTLS": "[true if your gitea server use self signed certificate]"
+}
+```
+
+2. Add the following settings to your
+
+- window: `%APPDATA%\Code\User\settings.json`
+- mac: `$HOME/Library/Application Support/Code/User/settings.json`
+- linux: `$HOME/.config/Code/User/settings.json`
+
+```json
+{
   "gitea.token": "[Access token for the user]"
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitea-integration",
-  "version": "1.0.5",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitea-integration",
-      "version": "1.0.5",
+      "version": "1.1.1",
       "dependencies": {
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -29,7 +29,7 @@
         "typescript": "^5.8.3"
       },
       "engines": {
-        "vscode": "^1.74.0"
+        "vscode": "^1.102.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,11 @@
         "gitea.token": {
           "type": "string",
           "description": "Gitea API token"
+        },
+        "gitea.allowInsecureTLS": {
+          "type": "boolean",
+          "description": "Allow insecure TLS connections (self-signed certificates)",
+          "default": false
         }
       }
     }

--- a/src/giteaService.ts
+++ b/src/giteaService.ts
@@ -25,6 +25,7 @@ import {
   EditReactionOption,
   // @ts-ignore
 } from "../types/_types";
+import * as https from "https";
 
 export class GiteaService {
   private client: AxiosInstance;
@@ -38,6 +39,8 @@ export class GiteaService {
   private createClient(): AxiosInstance {
     const instanceURL = this.config.get<string>("instanceURL");
     const token = this.config.get<string>("token");
+    const allowInsecureTLS = this.config.get<boolean>("allowInsecureTLS");
+    let httpsAgent;
 
     if (!instanceURL) {
       throw new Error("Gitea instance URL not configured");
@@ -47,13 +50,22 @@ export class GiteaService {
       throw new Error("Gitea token not configured");
     }
 
-    return axios.create({
+    if (allowInsecureTLS) {
+      httpsAgent = new https.Agent({
+        rejectUnauthorized: false,
+      });
+    }
+
+    const axiosConfig = {
       baseURL: `${instanceURL}/api/v1`,
       headers: {
         Authorization: `token ${token}`,
         "Content-Type": "application/json",
       },
-    });
+      httpsAgent,
+    };
+
+    return axios.create(axiosConfig);
   }
 
   private getRepoPath(): string {


### PR DESCRIPTION
# What I modified

`giteaService.ts` to define `httpsAgent` with `rejectUnauthorized: false` when user set `allowInsecureTLS` option to `true`

# Expected

Users that uses Gitea server with self signed certificate should add `gitea.allowInsecureTLS` to `true`. and Axios skips verifying tls.

Closes #10 